### PR TITLE
fixes #126 - Get rid of the cached nodes when they are removed and haven't been sent to the toolbox

### DIFF
--- a/lib/chromium/walker.js
+++ b/lib/chromium/walker.js
@@ -598,6 +598,10 @@ var ChromiumWalkerActor = ActorClass({
     this.orphaned.push(node);
 
     if (!node.sent) {
+      // Node hasn't been sent to the toolbox yet, so no need to queue a mutation
+      // but make sure to keep the cached parent's children list updated.
+      let index = node.parent.children.findIndex(n => n.handle.nodeId === params.nodeId);
+      node.parent.children.splice(index, 1);
       return;
     }
 


### PR DESCRIPTION
I'm unsure about this fix, but it does work.
I don't see why we should maintain the list of handle children ourselves really.
It's been long enough since the last time I worked on Valence for me to not feel very comfortable about this particular fix.