### PR TITLE
Use the Valence moniker everywhere (fixes #104)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 FILES=data lib package.json README.md bootstrap.js
-ADDON_NAME=fxdt-adapters
+ADDON_NAME=valence
 ADDON_VERSION=0.2.5pre
 XPI_NAME=$(ADDON_NAME)-$(ADDON_VERSION)
 
-FTP_ROOT_PATH=/pub/mozilla.org/labs/fxdt-adapters
+FTP_ROOT_PATH=/pub/mozilla.org/labs/valence
 
 UPDATE_LINK=https://ftp.mozilla.org$(FTP_ROOT_PATH)/
 UPDATE_URL=$(UPDATE_LINK)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Firefox Developer Tools Adapter
-===============================
+Valence
+=======
 
 This add-on provides the ability for you to debug various remote targets from the Firefox Developer Tools. The idea is that you can use one solid set of developer tools to debug all the things you need. This is the dream, anyhow. We're going to try and make this happen.
 
@@ -22,7 +22,7 @@ Installation for All Y'all
 
 Before you can build and run the extension, here are a few things you'll need to do:
 
-1. `git clone git@github.com:campd/fxdt-adapters.git`
+1. `git clone git@github.com:campd/valence.git`
 
 2. Make sure you have an updated copy of Firefox Nightly installed. If you need to install Nightly, you can get it [here](https://nightly.mozilla.org/).
 
@@ -48,7 +48,7 @@ For example, on OSX, you could run the following command to start a debuggable c
 
     > /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222 --no-first-run --no-default-browser-check --user-data-dir=$(mktemp -d -t 'chrome-remote_data_dir')
 
-If you click on the toolbar button and nothing happens, you most likely don't have anything running on port 9222.  Check the [Browser Console](https://developer.mozilla.org/en-US/docs/Tools/Browser_Console) to see what has gone wrong.
+If you click on the toolbar button and nothing happens, you most likely don't have anything running on port 9222.  Check the [Browser Console](https://developer.mozilla.org/docs/Tools/Browser_Console) to see what has gone wrong.
 
 Debugging Chrome on Android
 -----------------

--- a/install.rdf
+++ b/install.rdf
@@ -17,10 +17,10 @@
     </em:targetApplication>
 
     <!-- Front End MetaData -->
-    <em:name>Firefox Developer Tools Adapters</em:name>
+    <em:name>Valence</em:name>
     <em:description>Protocol Adapters for Firefox Developer Tools</em:description>
     <em:creator>Dave Camp</em:creator>
-    <em:homepageURL>https://github.com/campd/fxdt-adapters</em:homepageURL>
+    <em:homepageURL>https://github.com/campd/valence</em:homepageURL>
 
   </Description>
 </RDF>

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "fxdevtools_adapters",
-  "title": "Firefox Developer Tools Adapters",
+  "name": "valence",
+  "title": "Valence",
   "id": "fxdevtools-adapters@mozilla.org",
   "description": "Protocol Adapters for Firefox Developer Tools",
   "author": "Dave Camp",
   "repository": {
     "type": "git",
-    "url": "https://github.com/campd/fxdt-adapters"
+    "url": "https://github.com/campd/valence"
   },
   "license": "MPL 2.0",
   "version": "0.0.1",

--- a/template/install.rdf
+++ b/template/install.rdf
@@ -17,10 +17,10 @@
     </em:targetApplication>
 
     <!-- Front End MetaData -->
-    <em:name>Firefox Developer Tools Adapters</em:name>
+    <em:name>Valence</em:name>
     <em:description>Protocol Adapters for Firefox Developer Tools</em:description>
     <em:creator>Dave Camp</em:creator>
-    <em:homepageURL>https://github.com/campd/fxdt-adapters</em:homepageURL>
+    <em:homepageURL>https://github.com/campd/valence</em:homepageURL>
     <em:updateURL>@@UPDATE_URL@@</em:updateURL>
 
   </Description>


### PR DESCRIPTION
I think I got everything apart from the addon id. I think changing that would break the update process for our installed user base. That means the pref names don't change either. 

I did change the FTP_ROOT_PATH though, which should require just a symlink on the server. I'm happy to leave it out however, if you think otherwise.

r? @jryans 