### PR TITLE
Stop eager loading of previews, since it makes autocompletion slow as mo...

### DIFF
--- a/lib/chromium/value.js
+++ b/lib/chromium/value.js
@@ -117,7 +117,6 @@ var ObjectGrip = ActorClass({
   }),
 
   prototypeAndProperties: asyncMethod(function*() {
-    const preview = require("./preview");
     let response = yield this.rpc.request("Runtime.getProperties", {
       objectId: this.handle.objectId,
       ownProperties: true
@@ -130,9 +129,6 @@ var ObjectGrip = ActorClass({
     };
 
     for (let prop of response.result) {
-      if ("value" in prop) {
-        yield preview.loadPreview(this.rpc, prop.value);
-      }
       if (prop.name === "__proto__") {
         ret.prototype = prop.value;
         continue;


### PR DESCRIPTION
...lasses

Fixes issue #130 and breaks console.table([[1, 2], [3, 4]]) as mentioned in there. I can't seem to find the time to debug this further and I want to cut a new release next week, so I'd rather have a single known broken case, than the entire feature being essentially broken.

I am certainly going to file a followup and fix it ASAP.

r? @captainbrosset 