### PR TITLE
Use a more generic 'iOS Runtime' moniker to account for Firefox for iOS ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ Debugging Chrome on Android
 
 In addition to the installation instructions, follow [these instructions](https://developer.chrome.com/devtools/docs/remote-debugging-legacy) to turn on remote debugging and set up adb.
 
-Debugging Safari and Firefox on iOS
+Debugging Safari, Firefox, and other WebViews on iOS
 -------------
 
 In addition to the installation instructions, you will need to enable developer support on your device. Follow the instructions on [this page](https://developer.apple.com/library/mac/documentation/AppleApplications/Conceptual/Safari_Developer_Guide/GettingStarted/GettingStarted.html) (in the "To enable Web Inspector on iOS" section) to get started.  Note: you can also use the iOS simulator if you have Xcode installed.
 
-Debugging Safari and Firefox on iOS is possible through the use of the following open source libraries that come bundled with this extension:
+Debugging Safari, Firefox, and other WebViews on iOS is possible through the use of the following open source libraries that come bundled with this extension:
 
 1. [ios_webkit_debug_proxy](https://github.com/google/ios-webkit-debug-proxy) version 1.4 on both OS X and Linux
 2. [libimobiledevice](https://github.com/libimobiledevice/libimobiledevice) version 1.1.5 on OS X, 1.2.0pre on Linux

--- a/README.md
+++ b/README.md
@@ -55,19 +55,19 @@ Debugging Chrome on Android
 
 In addition to the installation instructions, follow [these instructions](https://developer.chrome.com/devtools/docs/remote-debugging-legacy) to turn on remote debugging and set up adb.
 
-Debugging Safari on iOS
+Debugging Safari and Firefox on iOS
 -------------
 
 In addition to the installation instructions, you will need to enable developer support on your device. Follow the instructions on [this page](https://developer.apple.com/library/mac/documentation/AppleApplications/Conceptual/Safari_Developer_Guide/GettingStarted/GettingStarted.html) (in the "To enable Web Inspector on iOS" section) to get started.  Note: you can also use the iOS simulator if you have Xcode installed.
 
-Debugging Safari on iOS is possible through the use of the following open source libraries that come bundled with this extension:
+Debugging Safari and Firefox on iOS is possible through the use of the following open source libraries that come bundled with this extension:
 
 1. [ios_webkit_debug_proxy](https://github.com/google/ios-webkit-debug-proxy) version 1.4 on both OS X and Linux
 2. [libimobiledevice](https://github.com/libimobiledevice/libimobiledevice) version 1.1.5 on OS X, 1.2.0pre on Linux
 3. [libplist](https://github.com/libimobiledevice/libplist) version 1.10 on OS X, 1.12pre on Linux
 4. [libusbmuxd](https://github.com/libimobiledevice/libusbmuxd) version 1.0.8 on OS X, 1.0.0pre on Linux
 
-On Windows we are using the [ios-webkit-debug-proxy-win32](https://github.com/artygus/ios-webkit-debug-proxy-win32) port, at changeset d4a8a9a3f8afbb4e0a76a19126e7cd495dd84283. An additional runtime requirement on Windows is to have iTunes installed, or at least the Apple Mobile Device Support and Apple Application Support applications that come with it.
+On Windows we are using the [ios-webkit-debug-proxy-win32](https://github.com/artygus/ios-webkit-debug-proxy-win32) port at changeset d4a8a9a3f8afbb4e0a76a19126e7cd495dd84283, until it gets merged back upstream. An additional runtime requirement on Windows is to have iTunes installed, or at least the Apple Mobile Device Support and Apple Application Support applications that come with it.
 
 Why did you start this project?
 -------------------------------

--- a/lib/util/scanner.js
+++ b/lib/util/scanner.js
@@ -114,7 +114,7 @@ var iOSRuntime = {
     return "ios";
   },
   get name() {
-    return "Safari on iOS";
+    return "iOS Runtime";
   },
 };
 

--- a/lib/util/scanner.js
+++ b/lib/util/scanner.js
@@ -114,7 +114,7 @@ var iOSRuntime = {
     return "ios";
   },
   get name() {
-    return "iOS Runtime";
+    return "Safari, Firefox, and other WebViews on iOS";
   },
 };
 


### PR DESCRIPTION
...and embedded WebViews

See here for more:

https://bugzilla.mozilla.org/show_bug.cgi?id=1131671

r? @jryans 