### PR TITLE
Change creator to Mozilla

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -19,7 +19,7 @@
     <!-- Front End MetaData -->
     <em:name>Valence</em:name>
     <em:description>Protocol Adapters for Firefox Developer Tools</em:description>
-    <em:creator>Dave Camp</em:creator>
+    <em:creator>Mozilla</em:creator>
     <em:homepageURL>https://github.com/campd/valence</em:homepageURL>
 
   </Description>

--- a/template/install.rdf
+++ b/template/install.rdf
@@ -19,7 +19,7 @@
     <!-- Front End MetaData -->
     <em:name>Valence</em:name>
     <em:description>Protocol Adapters for Firefox Developer Tools</em:description>
-    <em:creator>Dave Camp</em:creator>
+    <em:creator>Mozilla</em:creator>
     <em:homepageURL>https://github.com/campd/valence</em:homepageURL>
     <em:updateURL>@@UPDATE_URL@@</em:updateURL>
 


### PR DESCRIPTION
Now that we auto-install the add-on after WebIDE open, we should make it more obvious that the add-on is from Mozilla and not this random Dave Camp guy.

r? @past 