### PR TITLE
Use 'cat' instead of 'grep' on Android, as it seems to be more prevalent

### DIFF
--- a/lib/util/scanner.js
+++ b/lib/util/scanner.js
@@ -148,7 +148,7 @@ function ChromeOnAndroidRuntime(device, model) {
 
 ChromeOnAndroidRuntime.detect = task.async(function*(device, model) {
   let runtimes = [];
-  let query = "grep -q chrome_devtools_remote /proc/net/unix; echo $?";
+  let query = "cat /proc/net/unix";
   let reply = yield device.shell(query);
   // XXX: Sometimes we get an empty response back.  Likely a bug in our shell
   // code in ADB Helper.
@@ -158,7 +158,7 @@ ChromeOnAndroidRuntime.detect = task.async(function*(device, model) {
       break;
     }
   }
-  if (reply === "0\r\n") {
+  if (/chrome_devtools_remote/.test(reply)) {
     let runtime = new ChromeOnAndroidRuntime(device, model);
     console.log("Found " + runtime.name);
     runtimes.push(runtime);


### PR DESCRIPTION
Fixes issue #99. 
r? @jryans 