### PR TITLE
Disable WebSocket compression extensions to work around a Chrome bug

### DIFF
--- a/lib/chromium/rpc.js
+++ b/lib/chromium/rpc.js
@@ -21,6 +21,11 @@ var TabConnection = Class({
         if (prefs["logDeviceProtocolTraffic"]) {
           console.log("<<<<<< Connecting to " + this.json.webSocketDebuggerUrl + "...");
         }
+        // TODO: remove this workaround for issue #136 when bug 1137008 is fixed.
+        const {Cu} = require("chrome");
+        Cu.import("resource://gre/modules/Services.jsm");
+        Services.prefs.setBoolPref("network.websocket.extensions.permessage-deflate", false);
+
         let socket = new WebSocket(this.json.webSocketDebuggerUrl, []);
         this.socket = socket;
         socket.onopen = () => {
@@ -34,6 +39,11 @@ var TabConnection = Class({
           if (prefs["logDeviceProtocolTraffic"]) {
             console.log(">>>>>> Web socket closed: " + e.code + "/" + e.reason);
           }
+
+          // TODO: remove this workaround for issue #136 when bug 1137008 is fixed.
+          const {Cu} = require("chrome");
+          Cu.import("resource://gre/modules/Services.jsm");
+          Services.prefs.clearUserPref("network.websocket.extensions.permessage-deflate");
         }
         socket.oncerror = e => console.error("Error occurred in web socket: " + e);
       });

--- a/lib/main.js
+++ b/lib/main.js
@@ -224,4 +224,9 @@ gcli.addItems(commands);
 
 unload.when(function () {
   gcli.removeItems(commands);
+  // TODO: remove this workaround for issue #136 when bug 1137008 is fixed.
+  Services.prefs.clearUserPref("network.websocket.extensions.permessage-deflate");
 });
+
+// TODO: remove this workaround for issue #136 when bug 1137008 is fixed.
+Services.prefs.setBoolPref("network.websocket.extensions.permessage-deflate", false);

--- a/lib/main.js
+++ b/lib/main.js
@@ -224,9 +224,4 @@ gcli.addItems(commands);
 
 unload.when(function () {
   gcli.removeItems(commands);
-  // TODO: remove this workaround for issue #136 when bug 1137008 is fixed.
-  Services.prefs.clearUserPref("network.websocket.extensions.permessage-deflate");
 });
-
-// TODO: remove this workaround for issue #136 when bug 1137008 is fixed.
-Services.prefs.setBoolPref("network.websocket.extensions.permessage-deflate", false);


### PR DESCRIPTION
Fixes issue #136. It will probably make the protocol connection slightly slower, but I can't say it is noticeable on my machine.

I'll file a followup to revert this once [bug 1137008](https://bugzilla.mozilla.org/show_bug.cgi?id=1137008) is fixed.

r? @jryans 