### PR TITLE
Change chrome-specific URLs to something that Firefox can handle

### DIFF
--- a/lib/chromium/root.js
+++ b/lib/chromium/root.js
@@ -180,10 +180,12 @@ var ChromiumTabActor = ActorClass({
   },
 
   form: function(detail) {
+    // Change chrome-specific URLs to something that Firefox can handle.
+    let url = this.json.url.replace(/^chrome:\/\//, "http://chrome-");
     return {
       actor: this.actorID,
       title: this.json.title,
-      url: this.json.url,
+      url: url,
       consoleActor: this.consoleActorID,
       inspectorActor: this.inspectorActorID,
       reflowActor: this.reflowActorID,


### PR DESCRIPTION
This lets WebIDE list and debug Chrome-specific pages, like chrome://settings, etc. See [bug 1134619](https://bugzilla.mozilla.org/show_bug.cgi?id=1134619) for more on the subject.

r? @ochameau