### PR TITLE
Don't try to autocomplete properties with hyphens in the name

### DIFF
--- a/lib/chromium/console-utils.js
+++ b/lib/chromium/console-utils.js
@@ -286,6 +286,9 @@ function* getMatchedPropsInObject(aObj, aMatch)
       if (prop.indexOf(aMatch) != 0) {
         continue;
       }
+      if (prop.indexOf('-') > -1) {
+        continue;
+      }
 
       // If it is an array index, we can't take it.
       // This uses a trick: converting a string to a number yields NaN if


### PR DESCRIPTION
Mirrors the fix from [bug 1130045](https://bugzilla.mozilla.org/show_bug.cgi?id=1130045).

r? @captainbrosset 