### PR TITLE
Fix comparison that was mistyped as an assignment

### DIFF
--- a/lib/chromium/console-utils.js
+++ b/lib/chromium/console-utils.js
@@ -207,7 +207,7 @@ function* JSPropertyProvider(aActor, aObj, aInputValue, aCursor)
       // The property to autocomplete is a member of array. For example
       // list[i][j]..[n]. Traverse the array to get the actual element.
       obj = yield getArrayMemberProperty(obj, prop);
-      if (obj.type = "string") {
+      if (obj.type == "string") {
         return yield getMatchedPropsInString(aActor, matchProp);
       }
     }


### PR DESCRIPTION
The Spidermonkey-specific strict warnings were useful for once: this assignment was indeed meant to be an equality comparison. Amusingly, git blame points to cset b2df730c by yours truly, with the indicative log message "oops". Oops, indeed.

Fixes the following in the console:
var foo = [{a:1}];
foo[0]. (doesn't suggest 'a' w/o this patch)

r? @jryans