### PR TITLE
Implement support for $_

### DIFF
--- a/lib/chromium/console-utils.js
+++ b/lib/chromium/console-utils.js
@@ -409,7 +409,7 @@ function JSTermHelpers(aOwner)
 {
   aOwner.sandbox.$ = noop;
   aOwner.sandbox.$$ = noop;
-  aOwner.sandbox.$_ = noop; // TODO: this probably needs local implementation.
+  aOwner.sandbox.$_ = noop; // Implemented in ChromiumConsoleActor.evaluateJS()
   aOwner.sandbox.$0 = noop;
   aOwner.sandbox.$1 = noop;
   aOwner.sandbox.$2 = noop;

--- a/lib/chromium/webconsole.js
+++ b/lib/chromium/webconsole.js
@@ -39,13 +39,23 @@ var ChromiumConsoleActor = ActorClass({
     Actor.prototype.initialize.call(this, tab.conn);
     this.rpc = tab.rpc;
 
-    this.rpc.on("Console.messageAdded", this.onMessage.bind(this));
-    this.rpc.on("Console.messageRepeatCountUpdated",
-      this.onMessageCountUpdated.bind(this));
+    this.onMessage = this.onMessage.bind(this);
+    this.onMessageCountUpdated = this.onMessageCountUpdated.bind(this);
+    this.rpc.on("Console.messageAdded", this.onMessage);
+    this.rpc.on("Console.messageRepeatCountUpdated", this.onMessageCountUpdated);
 
     this.enabledListeners = new Set();
     this.messageCache = {};
     this.clearMessagesCache();
+    this._jstermHelpersCache = null;
+  },
+
+  disconnect: function() {
+    this.rpc.off("Console.messageAdded", this.onMessage);
+    this.rpc.off("Console.messageRepeatCountUpdated", this.onMessageCountUpdated);
+    this.messageCache = null;
+    this.enabledListeners = null;
+    this._jstermHelpersCache = null;
   },
 
   cacheOrSend: task.async(function*(type, payload) {
@@ -259,7 +269,7 @@ var ChromiumConsoleActor = ActorClass({
   evaluateJS: asyncMethod(function*(expression) {
     let response = yield this.rpc.request("Runtime.evaluate", {
       expression: expression,
-      includeCommandLineAPI: true, // XXX: hrm?
+      includeCommandLineAPI: true,
     });
 
     yield preview.loadPreview(this.rpc, response.result);
@@ -282,6 +292,19 @@ var ChromiumConsoleActor = ActorClass({
     } else {
       result = response.result;
     }
+
+    // Set $_ for future availability.
+    let lastResult = response.result.objectId;
+    // If not an object, provide an descriptive error to inform the user.
+    if (!lastResult) {
+      let boxed = yield this.rpc.request("Runtime.evaluate", {
+        expression: "Error('Sorry, Valence cannot set $_ to primitive values')",
+      });
+      lastResult = boxed.result.objectId;
+    }
+    yield this.rpc.request("Console.setLastEvaluationResult", {
+      objectId: lastResult
+    });
 
     return {
       input: expression,


### PR DESCRIPTION
The WebKit protocol has some limited support to set $_ that we can use. Unfortunately it doesn't work with primitive values, so in this patch I just use an error message to explain what happened.

I tried boxing primitives to cover more cases, but the console displays boxed values different than primitive values and it was confusing. On the other hand if people mainly don't just inspect $_, but use it in expressions, it might be not that bad (or even worse). Since this solution wouldn't cover null and undefined, I decided to play it safe.

@bgrins what do you think?